### PR TITLE
Implement CASP instructions

### DIFF
--- a/plugins/arm/semantics/aarch64-atomic.lisp
+++ b/plugins/arm/semantics/aarch64-atomic.lisp
@@ -11,7 +11,7 @@
    load and store are functions to load/store to/from the size of rs and rt.
    acquire and release are booleans indicating whether load-acquire and
    store-release ordering is to be enforced."
-   (let ((data (load rn)))
+  (let ((data (load rn)))
     (when acquire (intrinsic 'load-acquire))
     (when (= data rs)
       (when release (intrinsic 'store-release))
@@ -61,6 +61,15 @@
 (defun CASLH  (rs _ rt rn) (CASordH rs rt rn false true))
 (defun CASALH (rs _ rt rn) (CASordH rs rt rn true  true))
 
+(defun first  (x y) (declare (visibility :private)) x)
+(defun second (x y) (declare (visibility :private)) y)
+
+(defun CASPX (rs_pair _ rt_pair rn)
+  (let ((data (load-dword rn)))
+    (when (= data (register-pair-concat rs_pair))
+      (store-word rn (register-pair-concat rt_pair)))
+    (set$ (register-pair-first rs_pair)  (endian first  (cast-high 64 data) (cast-low 64 data)))
+    (set$ (register-pair-second rs_pair) (endian second (cast-high 64 data) (cast-low 64 data)))))
 
 (defmacro CSop*r (set op rd rn rm cnd)
   "(CSop*r set op rd rn rm cnd) implements the conditional select

--- a/plugins/arm/semantics/aarch64-atomic.lisp
+++ b/plugins/arm/semantics/aarch64-atomic.lisp
@@ -64,22 +64,40 @@
 (defun first  (x y) (declare (visibility :private)) x)
 (defun second (x y) (declare (visibility :private)) y)
 
-(defmacro CASP* (set load rs-pair rt-pair rn register-width)
-  "(CASP* set load store rs-pair rt-pair rn register-width)
+(defmacro CASPord* (set load rs-pair rt-pair rn register-width acquire release)
+  "(CASP* set load store rs-pair rt-pair rn register-width acquire release)
    implements a compare-and-swap-pair instruction for W and X registers.
    set is the functions to set to a register in the pair.
    register-width is 64 or 32, depending on the size of register used.
-   load either loads 128 bits or 64 (the size of the whole pair)."
+   load either loads 128 bits or 64 (the size of the whole pair).
+   acquire and release are as in the CASord* macro."
   (let ((data (load rn))
         (lower (cast-low  register-width data))
         (upper (cast-high register-width data)))
+    (when acquire (intrinsic 'load-acquire))
     (when (= data (register-pair-concat rs-pair))
+      (when release (intrinsic 'store-release))
       (store-word rn (register-pair-concat rt-pair)))
     (set (register-pair-first  rs-pair) (endian first  upper lower))
     (set (register-pair-second rs-pair) (endian second upper lower))))
 
-(defun CASPX (rs-pair _ rt-pair rn) (CASP* set$ load-dword rs-pair rt-pair rn 64))
-(defun CASPW (rs-pair _ rt-pair rn) (CASP* setw load-word rs-pair rt-pair rn 32))
+(defmacro CASPordX (rs-pair rt-pair rn acquire release)
+  "Specialisation of CASPord* for X registers."
+  (CASPord* set$ load-dword rs-pair rt-pair rn 64 acquire release))
+
+(defmacro CASPordW (rs-pair rt-pair rn acquire release)
+  "Specialisation of CASPord* for W registers."
+  (CASPord* setw load-word rs-pair rt-pair rn 32 acquire release))
+
+(defun CASPX   (rs-pair _ rt-pair rn) (CASPordX rs-pair rt-pair rn false false))
+(defun CASPAX  (rs-pair _ rt-pair rn) (CASPordX rs-pair rt-pair rn true  false))
+(defun CASPLX  (rs-pair _ rt-pair rn) (CASPordX rs-pair rt-pair rn false true))
+(defun CASPALX (rs-pair _ rt-pair rn) (CASPordX rs-pair rt-pair rn true  true))
+
+(defun CASPW   (rs-pair _ rt-pair rn) (CASPordW rs-pair rt-pair rn false false))
+(defun CASPAW  (rs-pair _ rt-pair rn) (CASPordW rs-pair rt-pair rn true  false))
+(defun CASPLW  (rs-pair _ rt-pair rn) (CASPordW rs-pair rt-pair rn false true))
+(defun CASPALW (rs-pair _ rt-pair rn) (CASPordW rs-pair rt-pair rn true  true))
 
 (defmacro CSop*r (set op rd rn rm cnd)
   "(CSop*r set op rd rn rm cnd) implements the conditional select

--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -146,7 +146,7 @@
 			(set$ vd (extract 127 0 (concat topPart element))))))
 
 (defun get-vector-S-element (index vn)
-	"(get-vector-S-element) returns the 32 bit element from vn[index]"
+	"(get-vector-S-element index vn) returns the 32 bit element from vn[index]"
   (case index
     0x0 (extract 31 0 vn)
     0x1 (extract 63 32 vn)
@@ -154,3 +154,115 @@
     0x3 (extract 127 96 vn)
     0x0))
 
+;; to generate these functions,
+;; do something like the following python code
+;;    for c in "XW":
+;;        for i in range(30//2):
+;;            print(f"'{c}{2*i}_{c}{2*i+1} '{c}{2*i}")
+(defun register-pair-first (r_pair)
+  "(register-pair-first r_pair) returns the first register in the
+   register pair Xi_X(i+1) or similar, returned by LLVM.
+   This is used in specific instructions like the CASP family and LD2."
+  (case (symbol r_pair)
+    'X0_X1   'X0
+    'X2_X3   'X2
+    'X4_X5   'X4
+    'X6_X7   'X6
+    'X8_X9   'X8
+    'X10_X11 'X10
+    'X12_X13 'X12
+    'X14_X15 'X14
+    'X16_X17 'X16
+    'X18_X19 'X18
+    'X20_X21 'X20
+    'X22_X23 'X22
+    'X24_X25 'X24
+    'X26_X27 'X26
+    'X28_X29 'X28
+    'W0_W1   'W0
+    'W2_W3   'W2
+    'W4_W5   'W4
+    'W6_W7   'W6
+    'W8_W9   'W8
+    'W10_W11 'W10
+    'W12_W13 'W12
+    'W14_W15 'W14
+    'W16_W17 'W16
+    'W18_W19 'W18
+    'W20_W21 'W20
+    'W22_W23 'W22
+    'W24_W25 'W24
+    'W26_W27 'W26
+    'W28_W29 'W28))
+
+(defun register-pair-second (r_pair)
+  "(register-pair-first r_pair) returns the second register in the
+   register pair Xi_X(i+1) or similar, returned by LLVM.
+   This is used in specific instructions like the CASP family and LD2."
+  (case (symbol r_pair)
+    'X0_X1   'X1
+    'X2_X3   'X3
+    'X4_X5   'X5
+    'X6_X7   'X7
+    'X8_X9   'X9
+    'X10_X11 'X11
+    'X12_X13 'X13
+    'X14_X15 'X15
+    'X16_X17 'X17
+    'X18_X19 'X19
+    'X20_X21 'X21
+    'X22_X23 'X23
+    'X24_X25 'X25
+    'X26_X27 'X27
+    'X28_X29 'X29
+    'W0_W1   'W1
+    'W2_W3   'W3
+    'W4_W5   'W5
+    'W6_W7   'W7
+    'W8_W9   'W9
+    'W10_W11 'W11
+    'W12_W13 'W13
+    'W14_W15 'W15
+    'W16_W17 'W17
+    'W18_W19 'W19
+    'W20_W21 'W21
+    'W22_W23 'W23
+    'W24_W25 'W25
+    'W26_W27 'W27
+    'W28_W29 'W29))
+
+(defun register-pair-concat (r_pair)
+  "(register-pair-concat r_pair) returns the concatenated form
+   of the register pair returned by LLVM, taking into account
+   the endianness."
+  (case (symbol r_pair)
+    'X0_X1   (endian concat X0 X1)
+    'X2_X3   (endian concat X2 X3)
+    'X4_X5   (endian concat X4 X5)
+    'X6_X7   (endian concat X6 X7)
+    'X8_X9   (endian concat X8 X9)
+    'X10_X11 (endian concat X10 X11)
+    'X12_X13 (endian concat X12 X13)
+    'X14_X15 (endian concat X14 X15)
+    'X16_X17 (endian concat X16 X17)
+    'X18_X19 (endian concat X18 X19)
+    'X20_X21 (endian concat X20 X21)
+    'X22_X23 (endian concat X22 X23)
+    'X24_X25 (endian concat X24 X25)
+    'X26_X27 (endian concat X26 X27)
+    'X28_X29 (endian concat X28 X29)
+    'W0_W1   (endian concat W0 W1)
+    'W2_W3   (endian concat W2 W3)
+    'W4_W5   (endian concat W4 W5)
+    'W6_W7   (endian concat W6 W7)
+    'W8_W9   (endian concat W8 W9)
+    'W10_W11 (endian concat W10 W11)
+    'W12_W13 (endian concat W12 W13)
+    'W14_W15 (endian concat W14 W15)
+    'W16_W17 (endian concat W16 W17)
+    'W18_W19 (endian concat W18 W19)
+    'W20_W21 (endian concat W20 W21)
+    'W22_W23 (endian concat W22 W23)
+    'W24_W25 (endian concat W24 W25)
+    'W26_W27 (endian concat W26 W27)
+    'W28_W29 (endian concat W28 W29)))

--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -159,11 +159,11 @@
 ;;    for c in "XW":
 ;;        for i in range(30//2):
 ;;            print(f"'{c}{2*i}_{c}{2*i+1} '{c}{2*i}")
-(defun register-pair-first (r_pair)
-  "(register-pair-first r_pair) returns the first register in the
+(defun register-pair-first (r-pair)
+  "(register-pair-first r-pair) returns the first register in the
    register pair Xi_X(i+1) or similar, returned by LLVM.
    This is used in specific instructions like the CASP family and LD2."
-  (case (symbol r_pair)
+  (case (symbol r-pair)
     'X0_X1   'X0
     'X2_X3   'X2
     'X4_X5   'X4
@@ -195,11 +195,11 @@
     'W26_W27 'W26
     'W28_W29 'W28))
 
-(defun register-pair-second (r_pair)
-  "(register-pair-first r_pair) returns the second register in the
+(defun register-pair-second (r-pair)
+  "(register-pair-first r-pair) returns the second register in the
    register pair Xi_X(i+1) or similar, returned by LLVM.
    This is used in specific instructions like the CASP family and LD2."
-  (case (symbol r_pair)
+  (case (symbol r-pair)
     'X0_X1   'X1
     'X2_X3   'X3
     'X4_X5   'X5
@@ -231,11 +231,11 @@
     'W26_W27 'W27
     'W28_W29 'W29))
 
-(defun register-pair-concat (r_pair)
-  "(register-pair-concat r_pair) returns the concatenated form
-   of the register pair returned by LLVM, taking into account
+(defun register-pair-concat (r-pair)
+  "(register-pair-concat r-pair) returns the concatenated values of
+   the register pair returned by LLVM, taking into account
    the endianness."
-  (case (symbol r_pair)
+  (case (symbol r-pair)
     'X0_X1   (endian concat X0 X1)
     'X2_X3   (endian concat X2 X3)
     'X4_X5   (endian concat X4 X5)


### PR DESCRIPTION
CASP instructions with load-acquire and store-release ordering are implemented in this PR.
Memory orderings are represented the same way as in #1458, e.g. `CASPAL x0, x1, x2, x3, [x4]` is lifted to
```
{
  #0 := mem[R4, el]:u128
  #1 := low:64[#0]
  #2 := high:64[#0]
  call(intrinsic:load-acquire)
  #4 := #0 = (R1.R0)
  if (#4) {
    call(intrinsic:store-release)
    mem := mem with [R4, el]:u128 <- R3.R2
  }
  R0 := #1
  R1 := #2
}
```