### PR TITLE
Implement base+simd/fp STR, STP, STUR instructions

### DIFF
--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -89,10 +89,21 @@
     (store-word (+ dst off (sizeof word)) t2)
     (set$ dst (+ dst off))))
 
+(defun STPWi (rt rt2 base imm) 
+  (let ((datasize 16) (off (* imm 4)))
+    (store-word (+ base off) rt)
+    (store-word (+ base off datasize) rt2)))
+
 (defun STPXi (t1 t2 base off)
-  (let ((off (lshift off 4)))
-    (store-word base (+ base off))
-    (store-word base (+ base off (sizeof word)))))
+  (let ((off (* off 8)))
+    (store-word (+ base off) t1)
+    (store-word (+ base off (sizeof word)) t2)))
+
+; signed offset STP (SIMD/FP)
+(defun STPQi (rt rt2 base imm) 
+  (let ((datasize 128) (off (* imm 16)))
+    (store-word (+ base off) rt)
+    (store-word (+ base off datasize) rt2)))
 
 (defun STRXui (src reg off)
   (let ((off (lshift off 3)))

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -80,8 +80,25 @@
 
 ;; ST...
 
+; STRB (base)
 (defun STRBBui (src reg off)
   (store-byte (+ reg off) src))
+
+; post-indexed STRB
+(defun STRBBpost (_ rt base simm)
+  (store-byte base rt)
+  (set$ base (+ base simm)))
+
+(defun STRBBroW (rt rn rm option shift)
+  (let ((off
+    (if (= option 1)
+        (signed-extend 32 rm)         ; SXTW
+      (unsigned-extend 32 rm))))      ; UXTW
+    (store-byte (+ rn off) rt)))
+
+(defun STRBBroX (rt rn rm option shift)
+  (let ((off (signed-extend 64 rm)))  ; SXTX
+    (store-byte (+ rn off) rt)))
 
 (defun STPXpre (dst t1 t2 _ off)
   (let ((off (lshift off 3)))
@@ -133,6 +150,3 @@
 (defun STURDi (rn rt imm) (STUR*i rn rt imm 64))
 (defun STURQi (rn rt imm) (STUR*i rn rt imm 128)) 
 
-
-; post-indexed and pre-indexed addressing means that the sum of the address and 
-; the offset is written back to the base register (C1-231). 

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -105,6 +105,7 @@
 (defun STRXroX (rt rn rm _ shift)
   (store-word (+ rn (lshift rm (* shift 3))) rt))
 
+; addr + offset indexed STUR
 (defmacro STUR*i (src base off size)
   "Takes `size` bits from src and stores at base + off"
   (store-word (+ base off) (cast-low size src)))
@@ -116,3 +117,11 @@
 (defun STURHHi  (src base off) (STUR*i src base off 16))
 
 (defun STURBBi (src base off) (STUR*i src base off 8))
+
+
+(defun STURDi (rn rt imm) (STUR*i rn rt imm 64))
+(defun STURQi (rn rt imm) (STUR*i rn rt imm 128)) 
+
+
+; post-indexed and pre-indexed addressing means that the sum of the address and 
+; the offset is written back to the base register (C1-231). 

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -110,7 +110,7 @@
  (str-reg 0 rt rn rm option shift))
 
 (defun STRHroX  (rt rn rm option shift)
- (str-reg 1 rt rn rm option shift))
+ (str-reg 1 (cast-low 16 rt) rn rm option shift))
 
 (defun STRSroX  (rt rn rm option shift)
  (str-reg 2 rt rn rm option shift))
@@ -132,7 +132,7 @@
  (str-reg 0 rt rn rm option shift))
 
 (defun STRHroW  (rt rn rm option shift)
- (str-reg 1 rt rn rm option shift))
+ (str-reg 1 (cast-low 16 rt) rn rm option shift))
 
 (defun STRSroW  (rt rn rm option shift)
  (str-reg 2 rt rn rm option shift))
@@ -145,7 +145,7 @@
 
 ; STRHHroX
 (defun STRHHroX (rt rn rm option shift)
-  (str-reg 0 rt rn rm option shift))
+  (str-reg 1 (cast-low 16 rt) rn rm option shift))
 
 ; STR (immediate) (base registers):
 (defun str-post (xreg src off)
@@ -206,7 +206,7 @@
 
 ; STRH (base reg), signed offset variant
 (defun STRHHui (rt rn off)
-  (store-word (+ rn off) (cast-low 16 rt)))
+  (store-word (+ rn (lshift off 1)) (cast-low 16 rt)))
 
 ; STRB post-indexed
 (defun STRBBpost (_ rt base simm)

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -85,26 +85,67 @@
   (store-byte (+ reg off) src))
 
 ; STR (register)
-(defun str-reg (rt rn rm signed shift)
+(defun str-reg (scale rt rn rm signed shift)
+  "stores rt to (rn + rm << (shift * scale)) with signed or unsigned extension 
+  of rm, where rt is a register of size (8 << scale). Note that rm can be an X 
+  or W register and it chooses the appropriate extend mode implicitly. rn must 
+  be an X register."
   (assert (< signed 2))
+  (assert-msg (= (word-width rt) (lshift 8 scale))
+      "(aarch64-data-movement.lisp:str-reg) scale must match size of rt") 
   (store-word (+ rn 
      (if (= signed 1) 
-       (signed-extend   (word-width rm) (lshift rm shift))
-       (unsigned-extend (word-width rm) (lshift rm shift)))) 
+       (signed-extend   (word-width rm) (lshift rm (* shift scale)))
+       (unsigned-extend (word-width rm) (lshift rm (* shift scale))))) 
       rt))
 
+; rm is an X register
 (defun STRWroX  (rt rn rm option shift)
- (str-reg rt rn rm option (* shift 2)))
+ (str-reg 2 rt rn rm option shift))
 
 (defun STRXroX (rt rn rm option shift)
- (str-reg rt rn rm option (* shift 3)))
+ (str-reg 3 rt rn rm option shift))
+
+(defun STRBroX  (rt rn rm option shift)
+ (str-reg 0 rt rn rm option shift))
+
+(defun STRHroX  (rt rn rm option shift)
+ (str-reg 1 rt rn rm option shift))
+
+(defun STRSroX  (rt rn rm option shift)
+ (str-reg 2 rt rn rm option shift))
+
+(defun STRDroX (rt rn rm option shift)
+  (str-reg 3 rt rn rm option shift))
 
 (defun STRQroX (rt rn rm option shift)
-  (str-reg rt rn rm option (* shift 4)))
+  (str-reg 4 rt rn rm option shift))
+
+; rm is a W register
+(defun STRWroW  (rt rn rm option shift)
+ (str-reg 2 rt rn rm option shift))
+
+(defun STRXroW (rt rn rm option shift)
+ (str-reg 3 rt rn rm option shift))
+
+(defun STRBroW  (rt rn rm option shift)
+ (str-reg 0 rt rn rm option shift))
+
+(defun STRHroW  (rt rn rm option shift)
+ (str-reg 1 rt rn rm option shift))
+
+(defun STRSroW  (rt rn rm option shift)
+ (str-reg 2 rt rn rm option shift))
+
+(defun STRDroW (rt rn rm option shift)
+  (str-reg 3 rt rn rm option shift))
+
+(defun STRQroW (rt rn rm option shift)
+  (str-reg 4 rt rn rm option shift))
 
 ; STRHHroX
 (defun STRHHroX (rt rn rm option shift)
-  (str-reg rt rn rm option shift))
+  (str-reg 0 rt rn rm option shift))
 
 ; STR (immediate) (base registers):
 (defun str-post (xreg src off)
@@ -138,7 +179,7 @@
   "Stores a register of size (8 << scale) to the memory address 
   (reg + (off << scale))."
   (assert-msg (= (word-width src) (lshift 8 scale))
-      "(aarch64-data-movement.lisp) scale must match size of register ") 
+      "(aarch64-data-movement.lisp:STR*ui) scale must match size of register") 
   (store-word (+ reg (lshift off scale)) 
     (cast-unsigned (lshift 8 scale) src)))
 

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -229,13 +229,13 @@
 
 ; STP
 
-(defun store-pair (scale indexing t1 t2 dst off) 
-  "store the pair t1,t2 of size (8 << scale)at the register dst plus an offset, 
+(defun store-pair (scale indexing t1 t2 dst imm) 
+  "store the pair t1,t2 of size (8 << scale) at the register dst plus an offset, 
   using the specified indexing."
   (assert-msg (and (= (word-width t1) (lshift 8 scale)) 
       (= (word-width t2) (lshift 8 scale)))
       "(aarch64-data-movement.lisp) scale must match size of register ") 
-  (let ((off (lshift off scale)) (datasize (lshift 8 scale))
+  (let ((off (lshift (cast-signed 64 imm) scale)) (datasize (lshift 8 scale))
       (addr (case indexing
               'post dst
               'pre  (+ dst off)
@@ -244,7 +244,7 @@
       "(aarch64-data-movement.lisp) invalid indexing scheme.")))
             )
     (store-word addr t1)
-    (store-word (+ addr datasize) t2)
+    (store-word (+ addr (/ datasize 8)) t2)
     (case indexing
        'post (set$ dst (+ addr off))
        'pre  (set$ dst addr)

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -137,9 +137,9 @@
 ; STRQui
 ; STRDui
 
-; STRH (base reg)
-; STRHHui
-
+; STRH (base reg), signed offset variant
+(defun STRHHui (rt rn off)
+  (store-word (+ rn off) (cast-low 16 rt)))
 
 ; post-indexed STRB
 (defun STRBBpost (_ rt base simm)


### PR DESCRIPTION
Implement all size and index variants of of STR, STP, and all sizes of STUR, 
including:

- `STPQi`: `STP q0, q1, [x2, #16]`
- `STPWi`: `STP w0, w1, [x2, #16]`
- `STRBBpost`: `STRB w0, [x2], #3`
- `STRBBroX`: `STRB w0, [x2, x3, LSL #0]` 
- `STRBBroW:` `STRB w0, [x2, w3, SXTW #0]`
- `STRDui`: `STR d0, [x2, #8]`
- `STRHHroX`: `STRH w0, [x2, x3, SXTX #1]`
- `STRHHui`: `STRH w0, [x2, #1]`
- `STRQpost`: `STR q0, [x2], #1`
- `STRQroX`: `STR q0, [x2, x3, SXTX #4]`
- `STRQui`:  `STR q0, [x2, #1]` 
- `STRWpost`: `STR w0, [x2], #1`
- `STRWroX`: `STR w0, [x2, x3, SXTX #2]`
- `STRXpost`: `STR x0, [x2], #5`
- `STRXroW`: `STR x0, [x2, w3, SXTW #0]`
- `STURdi`: `STUR d0, [x1, #1]`
- `STURdi`: `STUR q0, [x1, #1]`

