### PR TITLE
Correct LD2 instruction

### DIFF
--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -136,16 +136,9 @@
 
 (defun insert-element-into-vector (vd index element size)
   "(insert-element-into-vector vd index element size) inserts element into vd[index], where size is in {8,16,32,64}"
-  (let ((highIndex (- (* size (+ index 1) 1)))
+  (let ((highIndex (-1 (* size (+ index 1))))
         (lowIndex (* size index)))
     (set$ vd (replace-bit-range vd highIndex lowIndex element))))
-;;        (mask (concat () () ()))
-;;        (topPart (rshift vd highIndex)))
-;;    (if (> index 0)
-;;        (let ((mask (replicate-to-fill (cast-low 1 0x1) lowIndex))
-;;              (bottomPart (logand vd mask)))
-;;          (set$ vd (extract 127 0 (concat topPart element bottomPart))))
-;;      (set$ vd (extract 127 0 (concat topPart element))))))
 
 (defun get-vector-S-element (index vn)
   "(get-vector-S-element) returns the 32 bit element from vn[index]"

--- a/plugins/arm/semantics/aarch64-vector.lisp
+++ b/plugins/arm/semantics/aarch64-vector.lisp
@@ -16,20 +16,23 @@
 ;;; LDs..
 
 (defun LD2Twov16b_POST (_ qa_qb xn xm) 
-  "(LD2Twov16b_POST redundant qa_qb xn imm) loads multiple 2-element structures from memory at address xn with offset imm and stores it in qa and qb with de-interleaving. NOTE: does not encode Security state & Exception level"
+  "(LD2Twov16b_POST _ qa_qb xn imm) loads multiple 2-element structures from memory at address xn with offset imm and stores it in qa and qb with de-interleaving. NOTE: does not encode Security state & Exception level"
   (let ((qa (get-first-128b-reg qa_qb))
         (qb (get-second-128b-reg qa_qb)))
-    (insert-a qa qb xn 0)
+    (insert-a qa qb xn 0 0 0)
     (set$ xn (+ xn xm))))
 
-(defun insert-a (qa qb address e)
-  (when (< e 16)
-    (insert-element-into-vector qa e (load-byte address) 8)
-    (insert-b qa qb (+ address 1) e)))
+(defun insert-a (qa qb addr e acc-a acc-b)
+  (if (< e 16)
+    (let ((temp (load-byte addr)))
+      (insert-b qa qb (+ addr 1) e (if (= e 0) temp (concat temp acc-a)) acc-b))
+    (prog
+      (set$ qa acc-a)
+      (set$ qb acc-b))))
 
-(defun insert-b (qa qb address e)
-  (insert-element-into-vector qb e (load-byte address) 8)
-  (insert-a qa qb (+ address 1) (+ e 1)))
+(defun insert-b (qa qb addr e acc-a acc-b)
+  (let ((temp (load-byte addr)))
+    (insert-a qa qb (+ addr 1) (+ e 1) acc-a (if (= e 0) temp (concat temp acc-b)))))
 
 (defmacro LDPvec*i (vn vm base imm size mem-load scale)
   "(LDP*i qn qm imm size mem-load scale) loads a pair of SIMD&FP registers from memory using the address base and an optional signed immediate offset. NOTE: does not CheckFPAdvSIMDEnabled64(), HaveMTE2Ext(), SetTagCheckedInstruction(), CheckSPAlignment(), Mem[... AccType_VEC]"


### PR DESCRIPTION
Instruction: `ld2 {v0.16b, v1.16b}, [x2], x3`
Opcode: `40 80 c3 4c`

```text
{
  #4 := mem[R2]
  #5 := mem[R2 + 1]
  #6 := mem[R2 + 2]
  #7 := mem[R2 + 3]
  #8 := mem[R2 + 4]
  #9 := mem[R2 + 5]
  #10 := mem[R2 + 6]
  #11 := mem[R2 + 7]
  #12 := mem[R2 + 8]
  #13 := mem[R2 + 9]
  #14 := mem[R2 + 0xA]
  #15 := mem[R2 + 0xB]
  #16 := mem[R2 + 0xC]
  #17 := mem[R2 + 0xD]
  #18 := mem[R2 + 0xE]
  #19 := mem[R2 + 0xF]
  #20 := mem[R2 + 0x10]
  #21 := mem[R2 + 0x11]
  #22 := mem[R2 + 0x12]
  #23 := mem[R2 + 0x13]
  #24 := mem[R2 + 0x14]
  #25 := mem[R2 + 0x15]
  #26 := mem[R2 + 0x16]
  #27 := mem[R2 + 0x17]
  #28 := mem[R2 + 0x18]
  #29 := mem[R2 + 0x19]
  #30 := mem[R2 + 0x1A]
  #31 := mem[R2 + 0x1B]
  #32 := mem[R2 + 0x1C]
  #33 := mem[R2 + 0x1D]
  #34 := mem[R2 + 0x1E]
  #35 := mem[R2 + 0x1F]
  V0 := #34.#32.#30.#28.#26.#24.#22.#20.#18.#16.#14.#12.#10.#8.#6.#4
  V1 := #35.#33.#31.#29.#27.#25.#23.#21.#19.#17.#15.#13.#11.#9.#7.#5
  R2 := R2 + R3
}
```