### PR TITLE
Add missing empty bin

### DIFF
--- a/plugins/arm/semantics/aarch64-arithmetic.lisp
+++ b/plugins/arm/semantics/aarch64-arithmetic.lisp
@@ -102,7 +102,6 @@
 
 (defun UMSUBLrrr (rd rn rm ra) (set$ rd (cast-low 64 (- ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
 
-
 (defun SMSUBLrrr (rd rn rm ra) (set$ rd (cast-signed 64 (- ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
 
 (defun UMULHrr (rd rn rm)

--- a/plugins/arm/semantics/aarch64-arithmetic.lisp
+++ b/plugins/arm/semantics/aarch64-arithmetic.lisp
@@ -100,6 +100,8 @@
 
 (defun SMADDLrrr (rd rn rm ra) (set$ rd (cast-signed 64 (+ ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
 
+(defun UMSUBLrrr (rd rn rm ra) (set$ rd (cast-low 64 (- ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
+
 (defun UMULHrr (rd rn rm)
   "multiplies rn and rm together and stores the high 64 bits of the resulting 
   128-bit value to the register rd"

--- a/plugins/arm/semantics/aarch64-arithmetic.lisp
+++ b/plugins/arm/semantics/aarch64-arithmetic.lisp
@@ -98,6 +98,8 @@
 
 (defun UMADDLrrr (rd rn rm ra) (set$ rd (cast-low 64 (+ ra (* rn rm)))))
 
+(defun SMADDLrrr (rd rn rm ra) (set$ rd (cast-signed 64 (+ ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
+
 (defun UMULHrr (rd rn rm)
   "multiplies rn and rm together and stores the high 64 bits of the resulting 
   128-bit value to the register rd"

--- a/plugins/arm/semantics/aarch64-arithmetic.lisp
+++ b/plugins/arm/semantics/aarch64-arithmetic.lisp
@@ -102,6 +102,9 @@
 
 (defun UMSUBLrrr (rd rn rm ra) (set$ rd (cast-low 64 (- ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
 
+
+(defun SMSUBLrrr (rd rn rm ra) (set$ rd (cast-signed 64 (- ra (* (cast-signed 64 rn) (cast-signed 64 rm))))))
+
 (defun UMULHrr (rd rn rm)
   "multiplies rn and rm together and stores the high 64 bits of the resulting 
   128-bit value to the register rd"

--- a/plugins/arm/semantics/aarch64-data-movement.lisp
+++ b/plugins/arm/semantics/aarch64-data-movement.lisp
@@ -173,6 +173,37 @@
   "(LDURBBi wt base simm) loads a byte from the address calculated from a base register and signed immediate offset and stores it in the 32 bit destination register. NOTE: does not HaveMTE2Ext(), SetTagCheckedInstruction(), CheckSPAlignment()"
   (setw wt (load-byte (+ base simm))))
 
+;; LDURH
+
+(defun LDURHHi (rt rn simm)
+  (setw rt (cast-unsigned 32 (load-dbyte (+ rn simm)))))
+
+;; LDURSB
+
+(defun LDURSBWi (rt rn simm)
+  "LDURSBWi loads a byte from the address (rn + simm) and sign-extends it to write it to rt"
+  (setw rt (cast-signed 32 (load-byte (+ rn simm)))))
+
+(defun LDURSBXi (rt rn simm)
+  "LDURSBXi loads a byte from the address (rn + simm) and sign-extends it to write it to rt"
+  (set$ rt (cast-signed 64 (load-byte (+ rn simm)))))
+
+;; LDURSH
+
+(defun LDURSHWi (rt rn simm)
+  "LDURSBWi loads a halfword from the address (rn + simm) and sign-extends it to write it to rt"
+  (setw rt (cast-signed 32 (load-dbyte (+ rn simm)))))
+
+(defun LDURSHXi (rt rn simm)
+  "LDURSBXi loads a halfword from the address (rn + simm) and sign-extends it to write it to rt"
+  (set$ rt (cast-signed 64 (load-dbyte (+ rn simm)))))
+
+;; LDURSW
+
+(defun LDURSWi (rt rn simm)
+  "LDURSBXi loads a word from the address (rn + simm) and sign-extends it to write it to rt"
+  (set$ rt (cast-signed 64 (load-hword (+ rn simm)))))
+
 ;; LDUR
 
 (defmacro LDUR*i (rt base simm setf mem-load)

--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -9,6 +9,11 @@
 
 (defun word () (word-width))
 
+(defun reverse-bits (bits) 
+  (if (> (word-width bits) 1)
+      (concat (cast-low 1 bits) (reverse-bits (cast-high (- (word-width bits) 1) bits)))
+  bits))
+
 (defun shift-encoded (rm off)
   "(shift-encoded rm off) decodes the 8-bit shift value
    into its type and offset, and shifts rm accordingly."

--- a/plugins/arm/semantics/aarch64-helper.lisp
+++ b/plugins/arm/semantics/aarch64-helper.lisp
@@ -9,10 +9,13 @@
 
 (defun word () (word-width))
 
+(defun _reverse-bits (bits i) 
+  (if (> i 0)
+      (concat (_reverse-bits bits (- i 1)) (select i bits))
+  (select i bits)))
+
 (defun reverse-bits (bits) 
-  (if (> (word-width bits) 1)
-      (concat (cast-low 1 bits) (reverse-bits (cast-high (- (word-width bits) 1) bits)))
-  bits))
+  (_reverse-bits bits (- (word-width bits) 1)))
 
 (defun shift-encoded (rm off)
   "(shift-encoded rm off) decodes the 8-bit shift value

--- a/plugins/arm/semantics/aarch64-logical.lisp
+++ b/plugins/arm/semantics/aarch64-logical.lisp
@@ -146,3 +146,6 @@
 
 (defun RORVXr (rd rn rm) (SHIFT*r set$ rotate-right 64 rd rn rm))
 (defun RORVWr (rd rn rm) (SHIFT*r setw rotate-right 32 rd rn rm))
+
+(defun RBITXr (rd rn) (set$ rd (reverse-bits rn)))
+(defun RBITWr (rd rn) (setw rd (reverse-bits rn)))

--- a/plugins/arm/semantics/aarch64-special.lisp
+++ b/plugins/arm/semantics/aarch64-special.lisp
@@ -26,4 +26,4 @@
   (intrinsic 'undefined-instruction))
 
 (defun BRK (option)
-  (intrinsic (symbol-concat 'software-breakpoint- (bitvec-to-symbol option '0x))))
+  (intrinsic 'software-breakpoint option))

--- a/plugins/arm/semantics/aarch64-vector.lisp
+++ b/plugins/arm/semantics/aarch64-vector.lisp
@@ -79,15 +79,15 @@
 (defun EORv16i8 (vd vn vm) (set$ vd (logxor vn vm)))
 
 ;; the ISA says NOT acts element-wise, but this is
-;; equivalent to just (lognot vn). Not sure why it does this.
-(defun NOTv8i8  (vd vn)    (set$ vd (lognot vn)))
-(defun NOTv16i8 (vd vn)    (set$ vd (lognot vn)))
+;; equivalent to just (lnot vn). Not sure why it does this.
+(defun NOTv8i8  (vd vn)    (set$ vd (lnot vn)))
+(defun NOTv16i8 (vd vn)    (set$ vd (lnot vn)))
 
 (defun ORRv8i8  (vd vn vm) (set$ vd (logor  vn vm)))
 (defun ORRv16i8 (vd vn vm) (set$ vd (logor  vn vm)))
 
-(defun ORNv8i8  (vd vn vm) (set$ vd (logor  vn (lognot vm))))
-(defun ORNv16i8 (vd vn vm) (set$ vd (logor  vn (lognot vm))))
+(defun ORNv8i8  (vd vn vm) (set$ vd (logor  vn (lnot vm))))
+(defun ORNv16i8 (vd vn vm) (set$ vd (logor  vn (lnot vm))))
 
 ;;; INS
 


### PR DESCRIPTION
Miscellaneous fixes and adding instructions

- fix: replace `lognot` with `lnot`
- LDURHH, LDURSB, LDURSH, LDURSW
- RBIT (and reverse-bits helper)
- UMSUBL,SMSUBL,UMADDL,SMADDL